### PR TITLE
#27 下書き機能を実装

### DIFF
--- a/app/controllers/api/posts_controller.rb
+++ b/app/controllers/api/posts_controller.rb
@@ -1,12 +1,12 @@
 class Api::PostsController < ApplicationController
   before_action :authenticate_user!, only: ['create', 'update', 'destroy']
   def index
-    @posts = Post.all
+    @posts = Post.published
     render :index, formats: :json, handlers: 'jbuilder'
   end
 
   def show
-    @post = Post.find(params[:id])
+    @post = Post.published.find(params[:id])
     render :show, formats: :json, handlers: 'jbuilder'
   end
 

--- a/app/javascript/components/PostCreate.vue
+++ b/app/javascript/components/PostCreate.vue
@@ -44,11 +44,10 @@
             data-vv-name="select"
             required
           ></v-select>
-          {{ grade_range }}
         </validation-provider>
         <validation-provider
           v-slot="{ errors }"
-          name="想定シーン"
+          name="シーンタイプ"
           rules="required"
         >
           <v-select
@@ -61,7 +60,24 @@
             data-vv-name="select"
             required
           ></v-select>
-          {{ scene_type }}
+        </validation-provider>
+        
+        <validation-provider
+          v-slot="{ errors }"
+          name="公開設定"
+          rules="required"
+        >
+          <v-select
+            v-model="status"
+            :items="status_select"
+            item-text="label"
+            item-value="value"
+            :error-messages="errors"
+            label="公開設定"
+            data-vv-name="select"
+            required
+          ></v-select>
+          {{status}}
         </validation-provider>
 
         <v-btn
@@ -107,6 +123,7 @@ export default {
     content: "",
     grade_range: "",
     scene_type: "",
+    status: "",
     grade_range_select: [
       { label: "小学生", value: "elementary" },
       { label: "中学生", value: "junior_high" },
@@ -114,6 +131,10 @@ export default {
     scene_type_select: [
       { label: "全校集会", value: "all_scholl_assembly" },
       { label: "行事", value: "event" },
+    ],
+    status_select: [
+      { label: "下書き（非公開）", value: "draft" },
+      { label: "公開", value: "published" },
     ],
   }),
   computed: {
@@ -150,8 +171,8 @@ export default {
             description: this.description,
             content: this.content,
             grade_range: this.grade_range,
-            status: "published",
             scene_type: this.scene_type,
+            status: this.status,
           },
           {
             headers: {
@@ -180,6 +201,7 @@ export default {
       this.content = "";
       this.grade_range = "";
       this.scene_type = "";
+      this.status = "";
       this.$refs.observer.reset();
     },
   },

--- a/app/javascript/components/Postings.vue
+++ b/app/javascript/components/Postings.vue
@@ -1,6 +1,78 @@
 <template>
-  <v-container class="grey lighten-5">
+<v-container class="grey lighten-5">
+  <h1>講話の管理</h1>
+  <v-tabs>
+  <v-tab href="#tab-1">公開中</v-tab>
+  <v-tab href="#tab-2">下書き</v-tab>
+  
+
+  <v-tab-item value="tab-1">
+    <v-row>
+      <v-col v-for="post in publishedFilter" :key="post.id" cols="12" sm="4">
+        <v-card class="mx-auto" max-width="344">
+          <v-img
+            src="https://cdn.vuetifyjs.com/images/cards/sunshine.jpg"
+            height="200px"
+          ></v-img>
+
+          <v-card-title>
+            {{ post.title }}
+          </v-card-title>
+
+          <v-card-subtitle>
+            {{ post.description }}
+          </v-card-subtitle>
+
+          <v-card-actions>
+            <v-btn color="orange lighten-2" text>
+              <router-link :to="'/postings/' + post.id">
+                講話の詳細ページへ
+              </router-link>
+            </v-btn>
+
+            <v-spacer></v-spacer>
+          </v-card-actions>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-tab-item>
+  <v-tab-item value="tab-2">
+    <v-row>
+      <v-col v-for="post in draftFilter" :key="post.id" cols="12" sm="4">
+        <v-card class="mx-auto" max-width="344">
+          <v-img
+            src="https://cdn.vuetifyjs.com/images/cards/sunshine.jpg"
+            height="200px"
+          ></v-img>
+
+          <v-card-title>
+            {{ post.title }}
+          </v-card-title>
+
+          <v-card-subtitle>
+            {{ post.description }}
+          </v-card-subtitle>
+
+          <v-card-actions>
+            <v-btn color="orange lighten-2" text>
+              <router-link :to="'/postings/' + post.id">
+                講話の詳細ページへ
+              </router-link>
+            </v-btn>
+
+            <v-spacer></v-spacer>
+          </v-card-actions>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-tab-item>
+</v-tabs>
+</v-container>
+</template>
+
+  <!-- <v-container class="grey lighten-5">
     <h1>投稿した講話一覧</h1>
+
     <v-row>
       <v-col v-for="post in posts" :key="post.id" cols="12" sm="4">
         <v-card class="mx-auto" max-width="344">
@@ -30,7 +102,7 @@
       </v-col>
     </v-row>
   </v-container>
-</template>  
+</template>   -->
 
 <script>
 import axios from "axios";
@@ -40,23 +112,49 @@ export default {
   data: function () {
     return {
       posts: [],
+      tab: null,
+      items: [
+        { tab: "公開中"  },
+        { tab: "下書き" },
+      ],
     };
   },
   computed: {
     ...mapState("auth", {
       headers: (state) => state.headers,
     }),
+    draftFilter() {
+      const data = this.posts;
+      const result = data.filter(function(post) {
+        return post.status == "draft"
+      });
+      return result;
+    },
+    publishedFilter() {
+      const data = this.posts;
+      const result = data.filter(function(post) {
+        return post.status == "published"
+      });
+      return result;
+    },
   },
-  mounted() {
-    axios
-      .get("/api/postings", {
-        headers: {
-          uid: this.headers["uid"],
-          "access-token": this.headers["access-token"],
-          client: this.headers["client"],
-        },
-      })
-      .then((res) => (this.posts = res.data.posts));
+
+  mounted () {
+    this.getPostings();
+  },
+
+  methods: {
+    getPostings() {
+      axios
+        .get("/api/postings", {
+          headers: {
+            uid: this.headers["uid"],
+            "access-token": this.headers["access-token"],
+            client: this.headers["client"],
+          },
+        })
+        .then((res) => (this.posts = res.data.posts));
+    },
   },
 };
 </script>

--- a/app/javascript/components/PostingsDetail.vue
+++ b/app/javascript/components/PostingsDetail.vue
@@ -13,10 +13,8 @@
     <h2>シーンタイプ</h2>
     　{{ post.scene_type }}
     <div>
-      <v-btn depressed color="secondary"> 下書きに戻す（非公開) </v-btn>
-
       <v-btn depressed color="success">
-        <router-link :to="{ path: `/postings/edit/${post.id}` }" class="btn"
+        <router-link style="text-decoration: none; color: inherit;"  :to="{ path: `/postings/edit/${post.id}` }" class="btn"
           >編集</router-link
         >
       </v-btn>

--- a/app/javascript/components/PostingsEdit.vue
+++ b/app/javascript/components/PostingsEdit.vue
@@ -64,6 +64,24 @@
           {{ scene_type }}
         </validation-provider>
 
+        <validation-provider
+          v-slot="{ errors }"
+          name="公開設定"
+          rules="required"
+        >
+          <v-select
+            v-model="status"
+            :items="status_select"
+            item-text="label"
+            item-value="value"
+            :error-messages="errors"
+            label="公開設定"
+            data-vv-name="select"
+            required
+          ></v-select>
+          {{ status }}
+        </validation-provider>
+
         <v-btn
           class="mr-4"
           type="submit"
@@ -108,6 +126,7 @@ export default {
     content: "",
     grade_range: "",
     scene_type: "",
+    status: "",
     grade_range_select: [
       { label: "小学生", value: "elementary" },
       { label: "中学生", value: "junior_high" },
@@ -116,12 +135,16 @@ export default {
       { label: "全校集会", value: "all_scholl_assembly" },
       { label: "行事", value: "event" },
     ],
+    status_select: [
+      { label: "下書き（非公開）", value: "draft" },
+      { label: "公開", value: "published" },
+    ],
   }),
   // post: {
   //   title: "",
   //   description: "",
   //   content: "",
-  //   grade_range: null,
+  //   grade_range: null,Ç
   //   scene_type: null,
   //   grade_range_select: ["小学生", "中学生"],
   //   scene_type_select: ["全校集会", "行事"],
@@ -169,6 +192,7 @@ export default {
           this.content = response.data.content;
           this.grade_range = response.data.grade_range;
           this.scene_type = response.data.scene_type;
+          this.status = response.data.status;
         });
     },
     updatePost: function () {
@@ -181,9 +205,9 @@ export default {
             title: this.title,
             description: this.description,
             content: this.content,
-            grade_range: this.ja_grade_range,
-            status: "published",
-            scene_type: this.ja_scene_type,
+            grade_range: this.grade_range,
+            scene_type: this.scene_type,
+            status: this.status,
           },
           {
             headers: {
@@ -208,6 +232,7 @@ export default {
       this.content = "";
       this.grade_range = "";
       this.scene_type = "";
+      this.status = "";
       this.$refs.observer.reset();
     },
   },

--- a/app/javascript/components/PostingsEdit.vue
+++ b/app/javascript/components/PostingsEdit.vue
@@ -44,7 +44,6 @@
             data-vv-name="select"
             required
           ></v-select>
-          {{ grade_range }}
         </validation-provider>
         <validation-provider
           v-slot="{ errors }"
@@ -61,7 +60,6 @@
             data-vv-name="select"
             required
           ></v-select>
-          {{ scene_type }}
         </validation-provider>
 
         <validation-provider
@@ -79,18 +77,18 @@
             data-vv-name="select"
             required
           ></v-select>
-          {{ status }}
         </validation-provider>
 
         <v-btn
           class="mr-4"
           type="submit"
           v-on:click="updatePost"
+          color="success"
           :disabled="invalid"
         >
           上記内容で更新する
         </v-btn>
-        <v-btn @click="clear"> 全て空にする </v-btn>
+        <v-btn color="blue-grey" class="white--text" @click="clear"> 全て空にする </v-btn>
       </form>
     </validation-observer>
   </v-container>

--- a/app/views/api/postings/index.json.jbuilder
+++ b/app/views/api/postings/index.json.jbuilder
@@ -1,6 +1,6 @@
 json.set! :posts do
   json.array! @posts do |post|
-    json.extract! post, :id, :title, :description, :content
+    json.extract! post, :id, :title, :description, :content, :status
   end
 end
 


### PR DESCRIPTION
### 実装概要

- 講話の新規作成画面に公開・下書きの選択フォームを追加
- 下書き設定した記事はindex画面に表示されない
- マイページメニューの講話管理画面ではタブにより公開。下書きの切り替え表示が可能