### PR TITLE
Add: 講話一覧、検索結果一覧の表示を改善 #42

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,12 @@ gem 'devise_token_auth'
 # 検索機能
 gem 'ransack'
 
+# enum
+gem 'enum_help'
+
+# I18n
+gem 'rails-i18n'
+
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use Active Model has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,8 @@ GEM
       activesupport (>= 5.0)
       request_store (>= 1.0)
       ruby2_keywords
+    enum_help (0.0.19)
+      activesupport (>= 3.0.0)
     erubi (1.10.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
@@ -209,6 +211,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.2)
       loofah (~> 2.3)
+    rails-i18n (7.0.3)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (6.1.5)
       actionpack (= 6.1.5)
       activesupport (= 6.1.5)
@@ -333,6 +338,7 @@ DEPENDENCIES
   devise
   devise_token_auth
   draper
+  enum_help
   factory_bot_rails
   faker
   fuubar
@@ -348,6 +354,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.5)
+  rails-i18n
   ransack
   rspec-rails
   rspec-request_describer

--- a/app/controllers/api/postings_controller.rb
+++ b/app/controllers/api/postings_controller.rb
@@ -1,8 +1,8 @@
 class Api::PostingsController < ApplicationController
-  before_action :authenticate_user!, only: ['index', 'show', 'delete', 'update']
+  before_action :authenticate_user!, only: %w[index show delete update]
   def index
-    @posts = current_user.posts
-    render :index, formats: :json, handlers: 'jbuilder'
+    @posts = current_user.posts.order(created_at: :desc)
+    render 'index', formats: :json, handlers: 'jbuilder'
   end
 
   def show
@@ -16,7 +16,7 @@ class Api::PostingsController < ApplicationController
       render 'show', formats: :json, handlers: 'jbuilder'
     else
       render json: @post.errors, status: :unprocessable_entity
-    end  
+    end
   end
 
   def destroy
@@ -25,7 +25,7 @@ class Api::PostingsController < ApplicationController
       head :no_content
     else
       render json: @post.errors, status: :unprocessable_entity
-    end  
+    end
   end
 
   private
@@ -33,5 +33,4 @@ class Api::PostingsController < ApplicationController
   def post_params
     params.permit(:title, :description, :content, :status, :grade_range, :scene_type)
   end
-
 end

--- a/app/controllers/api/posts_controller.rb
+++ b/app/controllers/api/posts_controller.rb
@@ -1,7 +1,7 @@
 class Api::PostsController < ApplicationController
   before_action :authenticate_user!, only: %i[create update destroy]
   def index
-    @posts = Post.published.order(created_at: :desc)
+    @posts = Post.published.preload(:user).order(created_at: :desc)
     render :index, formats: :json, handlers: 'jbuilder'
   end
 
@@ -38,7 +38,7 @@ class Api::PostsController < ApplicationController
   end
 
   def search
-    @q = Post.ransack(search_params)
+    @q = Post.preload(:user).ransack(search_params)
     @posts = @q.result(distinct: true).order(created_at: :desc)
     render :search, formats: :json, handlers: 'jbuilder'
   end

--- a/app/javascript/components/MyProfile.vue
+++ b/app/javascript/components/MyProfile.vue
@@ -9,7 +9,7 @@
     <h2>一言自己紹介</h2>
     {{ profile.self_introduction }}
     <h2>ステータス</h2>
-    {{ profile.status }}
+    {{ profile.status_ja }}
     <h2>都道府県</h2>
     {{ profile.prefecture }}
     <div>

--- a/app/javascript/components/MyProfileEdit.vue
+++ b/app/javascript/components/MyProfileEdit.vue
@@ -28,6 +28,8 @@
           <v-select
             v-model="status"
             :items="status_select"
+            item-text="label"
+            item-value="value"
             :error-messages="errors"
             label="ステータス"
             data-vv-name="select"
@@ -94,11 +96,11 @@ export default {
     status: "",
     prefecture: "",
     status_select: [
-      "未設定",
-      "小学校校長",
-      "中学校校長",
-      "元小学校校長",
-      "元中学校校長",
+      { label: "未設定", value: "not_set" },
+      { label: "現小学校校長", value: "elementary_school_principal" },
+      { label: "現中学校校長", value: "junior_high_school_principal" },
+      { label: "元小学校校長", value: "former_elementary_school_principal" },
+      { label: "元中学校校長", value: "former_junior_high_school_principal:" },
     ],
     prefecture_select: [
       "未設定",
@@ -189,23 +191,6 @@ export default {
           status: this.status,
           prefecture: this.prefecture,
         })
-        // axios
-        //   .put(
-        //     `/auth`,
-        //     {
-        //       name: this.name,
-        //       self_introduction: this.self_introduction,
-        //       status: this.status,
-        //       prefecture: this.prefecture,
-        //     },
-        //     {
-        //       headers: {
-        //         uid: this.headers["uid"],
-        //         "access-token": this.headers["access-token"],
-        //         client: this.headers["client"],
-        //       },
-        //     }
-        //   )
         .then(
           (response) => {
             this.$router.push({ name: "MyProfile" });

--- a/app/javascript/components/PostCreate.vue
+++ b/app/javascript/components/PostCreate.vue
@@ -3,6 +3,7 @@
     <h1>新規投稿</h1>
     <validation-observer ref="observer" v-slot="{ invalid }">
       <form @submit.prevent="submit">
+        <!-- タイトル -->
         <validation-provider
           v-slot="{ errors }"
           name="タイトル"
@@ -12,23 +13,30 @@
             v-model="title"
             :error-messages="errors"
             label="タイトル"
-            required
           ></v-text-field>
         </validation-provider>
-        <v-text-field
-          v-model="description"
-          label="投稿者から一言！"
-        ></v-text-field>
 
+        <!-- 講話の紹介 -->
+        <validation-provider v-slot="{ errors }" name="講話の紹介" rules="required">
+        <v-textarea
+          v-model="description"
+          label="講話の紹介"
+          :error-messages="errors"
+          rows="4"
+        ></v-textarea>
+        </validation-provider>
+
+        <!-- 本文 -->
         <validation-provider v-slot="{ errors }" name="本文" rules="required">
           <v-textarea
             v-model="content"
             :error-messages="errors"
             label="本文"
             auto-grow
-            required
           ></v-textarea>
         </validation-provider>
+
+        <!-- 対象選択 -->
         <validation-provider
           v-slot="{ errors }"
           name="対象学年"
@@ -42,9 +50,10 @@
             :error-messages="errors"
             label="対象学年"
             data-vv-name="select"
-            required
           ></v-select>
         </validation-provider>
+
+        <!-- シーン選択 -->
         <validation-provider
           v-slot="{ errors }"
           name="シーンタイプ"
@@ -58,10 +67,10 @@
             :error-messages="errors"
             label="シーンタイプ"
             data-vv-name="select"
-            required
           ></v-select>
         </validation-provider>
         
+        <!-- 公開設定 -->
         <validation-provider
           v-slot="{ errors }"
           name="公開設定"
@@ -75,7 +84,6 @@
             :error-messages="errors"
             label="公開設定"
             data-vv-name="select"
-            required
           ></v-select>
         </validation-provider>
 
@@ -130,7 +138,7 @@ export default {
       { label: "中学生", value: "junior_high" },
     ],
     scene_type_select: [
-      { label: "全校集会", value: "all_scholl_assembly" },
+      { label: "全校集会", value: "all_school_assembly" },
       { label: "行事", value: "event" },
     ],
     status_select: [

--- a/app/javascript/components/PostDetail.vue
+++ b/app/javascript/components/PostDetail.vue
@@ -2,16 +2,18 @@
   <v-container>
     <h1>記事詳細</h1>
     <v-divider></v-divider>
+    <h2>投稿ユーザー</h2>
+    {{ post.user.name }}
     <h2>タイトル</h2>
     {{ post.title }}
-    <h2>投稿者より一言</h2>
+    <h2>投稿者から講話の紹介</h2>
     {{ post.description }}
     <h2>本文</h2>
     {{ post.content }}
     <h2>対象</h2>
-    {{ post.grade_range }}
+    {{ post.grade_range_ja }}
     <h2>シーンタイプ</h2>
-    {{ post.scene_type }}
+    {{ post.scene_type_ja }}
   </v-container>
 </template>
 

--- a/app/javascript/components/PostIndex.vue
+++ b/app/javascript/components/PostIndex.vue
@@ -1,44 +1,59 @@
 <template>
   <v-container class="grey lighten-5">
-    <h1>講話一覧</h1>
+    <h1>講話一覧（新着順）</h1>
     <v-row>
       <v-col v-for="post in this.viewPosts" :key="post.id" cols="12" sm="4">
         <v-card class="mx-auto" max-width="344">
-          <v-img
-            src="https://cdn.vuetifyjs.com/images/cards/sunshine.jpg"
-            height="200px"
-          ></v-img>
-
-          <v-card-title>
-            {{ post.title }}
-          </v-card-title>
-
-          <v-card-subtitle>
-            {{ post.description }}
-          </v-card-subtitle>
-
-          <v-card-actions>
-            <v-btn color="orange lighten-2" text>
-              <router-link :to="{ path: `/post/${post.id}` }">
-                講話の詳細ページへ
+          <v-card-text>
+            <div>投稿者: {{ post.user.name }}</div>
+            <div>
+              <router-link
+                :to="{ path: `/post/${post.id}` }"
+                style="text-decoration: none"
+              >
+                <p class="text-h5 orange--text">{{ post.title }}</p>
               </router-link>
-            </v-btn>
-
-            <v-spacer></v-spacer>
-          </v-card-actions>
+            </div>
+            <p>{{ post.grade_range_ja }} {{ post.scene_type_ja }}</p>
+            <p>更新日 {{ formatDate(post.updated_at) }}</p>
+            <!-- readmore部分 -->
+            <div>
+              <p>
+                <span v-if="!post.readActivated">
+                {{ post.description.slice(0, 100) }}
+                </span>
+                <button
+                  class="blue--text"
+                  v-if="!post.readActivated && post.description.length > 100"
+                  @click="post.readActivated = !post.readActivated"
+                >
+                  ...もっと読む
+                </button>
+              </p>
+              <p v-if="post.readActivated">{{ post.description }}</p>
+              <button
+                class="read blue--text"
+                v-if="post.readActivated"
+                @click="post.readActivated = !post.readActivated"
+              >
+                閉じる
+              </button>
+            </div>
+          </v-card-text>
         </v-card>
       </v-col>
-      <v-pagination
-        v-model="page"
-        :length="length"
-        @input="handlePageChange"
-      ></v-pagination>
     </v-row>
+    <v-pagination
+      v-model="page"
+      :length="length"
+      @input="handlePageChange"
+    ></v-pagination>
   </v-container>
-</template>  
+</template>
 
 <script>
 import axios from "axios";
+import dayjs from "dayjs";
 export default {
   name: "PostIndex",
   data: function () {
@@ -47,20 +62,31 @@ export default {
       viewPosts: [],
       length: 0,
       page: 1,
-      pageSize:12
+      pageSize: 12,
     };
   },
   async mounted() {
-    await axios.get("/api/posts").then((res) => (this.posts = res.data.posts)
-    );
-    this.length = Math.ceil(this.posts.length/this.pageSize);
-    this.viewPosts = this.posts.slice(0,this.pageSize);
+    await axios.get("/api/posts").then((res) => {
+      const posts = res.data.posts;
+      for (const post of posts) {
+        post.readActivated = false;
+      }
+      this.posts = posts;
+    });
+    this.length = Math.ceil(this.posts.length / this.pageSize);
+    this.viewPosts = this.posts.slice(0, this.pageSize);
+    console.info(dayjs().format());
   },
 
   methods: {
     handlePageChange: function (pageNumber) {
-      this.viewPosts = this.posts.slice(this.pageSize * (pageNumber - 1),this.pageSize * (pageNumber))
+      this.viewPosts = this.posts.slice(
+        this.pageSize * (pageNumber - 1),
+        this.pageSize * pageNumber
+      );
     },
+
+    formatDate: (dateStr) => dayjs(dateStr).format("YYYY年MM月DD日"),
   },
 };
 </script>

--- a/app/javascript/components/Postings.vue
+++ b/app/javascript/components/Postings.vue
@@ -1,122 +1,122 @@
 <template>
-<v-container class="grey lighten-5">
-  <h1>講話の管理</h1>
-  <v-tabs>
-  <v-tab href="#tab-1">公開中</v-tab>
-  <v-tab href="#tab-2">下書き</v-tab>
-  
-
-  <v-tab-item value="tab-1">
-    <v-row>
-      <v-col v-for="post in publishedFilter" :key="post.id" cols="12" sm="4">
-        <v-card class="mx-auto" max-width="344">
-          <v-img
-            src="https://cdn.vuetifyjs.com/images/cards/sunshine.jpg"
-            height="200px"
-          ></v-img>
-
-          <v-card-title>
-            {{ post.title }}
-          </v-card-title>
-
-          <v-card-subtitle>
-            {{ post.description }}
-          </v-card-subtitle>
-
-          <v-card-actions>
-            <v-btn color="orange lighten-2" text>
-              <router-link :to="'/postings/' + post.id">
-                講話の詳細ページへ
-              </router-link>
-            </v-btn>
-
-            <v-spacer></v-spacer>
-          </v-card-actions>
-        </v-card>
-      </v-col>
-    </v-row>
-  </v-tab-item>
-  <v-tab-item value="tab-2">
-    <v-row>
-      <v-col v-for="post in draftFilter" :key="post.id" cols="12" sm="4">
-        <v-card class="mx-auto" max-width="344">
-          <v-img
-            src="https://cdn.vuetifyjs.com/images/cards/sunshine.jpg"
-            height="200px"
-          ></v-img>
-
-          <v-card-title>
-            {{ post.title }}
-          </v-card-title>
-
-          <v-card-subtitle>
-            {{ post.description }}
-          </v-card-subtitle>
-
-          <v-card-actions>
-            <v-btn color="orange lighten-2" text>
-              <router-link :to="'/postings/' + post.id">
-                講話の詳細ページへ
-              </router-link>
-            </v-btn>
-
-            <v-spacer></v-spacer>
-          </v-card-actions>
-        </v-card>
-      </v-col>
-    </v-row>
-  </v-tab-item>
-</v-tabs>
-</v-container>
+  <v-container class="grey lighten-5">
+    <h1>講話の管理</h1>
+    <v-tabs>
+      <v-tab href="#tab-1">公開中</v-tab>
+      <v-tab href="#tab-2">下書き</v-tab>
+      <!-- 公開中 -->
+      <v-tab-item value="tab-1">
+        <v-row>
+          <v-col
+            v-for="post in publishedFilter"
+            :key="post.id"
+            cols="12"
+            sm="4"
+          >
+            <v-card class="mx-auto" max-width="344">
+              <v-card-text>
+                <div>
+                  <router-link
+                    :to="{ path: `/post/${post.id}` }"
+                    style="text-decoration: none"
+                  >
+                    <p class="text-h5 orange--text">{{ post.title }}</p>
+                  </router-link>
+                </div>
+                <p>{{ post.grade_range_ja }} {{ post.scene_type_ja }}</p>
+                <p>更新日 {{ formatDate(post.updated_at) }}</p>
+                <!-- readmore部分 -->
+                <div>
+                  <p>
+                    <span v-if="!post.readActivated">
+                      {{ post.description.slice(0, 100) }}
+                    </span>
+                    <button
+                      class="blue--text"
+                      v-if="
+                        !post.readActivated && post.description.length > 100
+                      "
+                      @click="post.readActivated = !post.readActivated"
+                    >
+                      ...もっと読む
+                    </button>
+                  </p>
+                  <p v-if="post.readActivated">{{ post.description }}</p>
+                  <button
+                    class="read blue--text"
+                    v-if="post.readActivated"
+                    @click="post.readActivated = !post.readActivated"
+                  >
+                    閉じる
+                  </button>
+                </div>
+              </v-card-text>
+            </v-card>
+          </v-col>
+        </v-row>
+      </v-tab-item>
+      <!-- 下書き -->
+      <v-tab-item value="tab-2">
+        <v-row>
+          <v-col v-for="post in draftFilter" :key="post.id" cols="12" sm="4">
+            <v-card class="mx-auto" max-width="344">
+              <v-card-text>
+                <div>
+                  <router-link
+                    :to="{ path: `/post/${post.id}` }"
+                    style="text-decoration: none"
+                  >
+                    <p class="text-h5 orange--text">{{ post.title }}</p>
+                  </router-link>
+                </div>
+                <p>{{ post.grade_range_ja }} {{ post.scene_type_ja }}</p>
+                <p>更新日 {{ formatDate(post.updated_at) }}</p>
+                <!-- readmore部分 -->
+                <div>
+                  <p>
+                    <span v-if="!post.readActivated">
+                      {{ post.description.slice(0, 100) }}
+                    </span>
+                    <button
+                      class="blue--text"
+                      v-if="
+                        !post.readActivated && post.description.length > 100
+                      "
+                      @click="post.readActivated = !post.readActivated"
+                    >
+                      ...もっと読む
+                    </button>
+                  </p>
+                  <p v-if="post.readActivated">{{ post.description }}</p>
+                  <button
+                    class="read blue--text"
+                    v-if="post.readActivated"
+                    @click="post.readActivated = !post.readActivated"
+                  >
+                    閉じる
+                  </button>
+                </div>
+              </v-card-text>
+            </v-card>
+          </v-col>
+        </v-row>
+      </v-tab-item>
+    </v-tabs>
+  </v-container>
 </template>
 
-  <!-- <v-container class="grey lighten-5">
-    <h1>投稿した講話一覧</h1>
-
-    <v-row>
-      <v-col v-for="post in posts" :key="post.id" cols="12" sm="4">
-        <v-card class="mx-auto" max-width="344">
-          <v-img
-            src="https://cdn.vuetifyjs.com/images/cards/sunshine.jpg"
-            height="200px"
-          ></v-img>
-
-          <v-card-title>
-            {{ post.title }}
-          </v-card-title>
-
-          <v-card-subtitle>
-            {{ post.description }}
-          </v-card-subtitle>
-
-          <v-card-actions>
-            <v-btn color="orange lighten-2" text>
-              <router-link :to="'/postings/' + post.id">
-                講話の詳細ページへ
-              </router-link>
-            </v-btn>
-
-            <v-spacer></v-spacer>
-          </v-card-actions>
-        </v-card>
-      </v-col>
-    </v-row>
-  </v-container>
-</template>   -->
 
 <script>
 import axios from "axios";
 import { mapState } from "vuex";
+import dayjs from "dayjs";
 export default {
   name: "Postings",
   data: function () {
     return {
       posts: [],
       tab: null,
-      items: [
-        { tab: "公開中"  },
-        { tab: "下書き" },
-      ],
+      items: [{ tab: "公開中" }, { tab: "下書き" }],
     };
   },
   computed: {
@@ -125,21 +125,21 @@ export default {
     }),
     draftFilter() {
       const data = this.posts;
-      const result = data.filter(function(post) {
-        return post.status == "draft"
+      const result = data.filter(function (post) {
+        return post.status == "draft";
       });
       return result;
     },
     publishedFilter() {
       const data = this.posts;
-      const result = data.filter(function(post) {
-        return post.status == "published"
+      const result = data.filter(function (post) {
+        return post.status == "published";
       });
       return result;
     },
   },
 
-  mounted () {
+  mounted() {
     this.getPostings();
   },
 
@@ -153,8 +153,15 @@ export default {
             client: this.headers["client"],
           },
         })
-        .then((res) => (this.posts = res.data.posts));
+        .then((res) => {
+          const posts = res.data.posts;
+          for (const post of posts) {
+            post.readActivated = false;
+          }
+          this.posts = posts;
+        });
     },
+    formatDate: (dateStr) => dayjs(dateStr).format("YYYY年MM月DD日"),
   },
 };
 </script>

--- a/app/javascript/components/PostingsDetail.vue
+++ b/app/javascript/components/PostingsDetail.vue
@@ -4,14 +4,14 @@
     <v-divider></v-divider>
     <h2>タイトル</h2>
     {{ post.title }}
-    <h2>投稿者より一言</h2>
+    <h2>投稿者から講話の紹介</h2>
     {{ post.description }}
     <h2>本文</h2>
     {{ post.content }}
     <h2>対象</h2>
-    　{{ post.grade_range }}
+    {{ post.grade_range_ja }}
     <h2>シーンタイプ</h2>
-    　{{ post.scene_type }}
+    {{ post.scene_type_ja }}
     <div>
       <v-btn depressed color="success">
         <router-link style="text-decoration: none; color: inherit;"  :to="{ path: `/postings/edit/${post.id}` }" class="btn"

--- a/app/javascript/components/PostingsEdit.vue
+++ b/app/javascript/components/PostingsEdit.vue
@@ -3,6 +3,7 @@
     <h1>講話の編集</h1>
     <validation-observer ref="observer" v-slot="{ invalid }">
       <form @submit.prevent="submit">
+        <!-- タイトル -->
         <validation-provider
           v-slot="{ errors }"
           name="タイトル"
@@ -12,23 +13,34 @@
             v-model="title"
             :error-messages="errors"
             label="タイトル"
-            required
           ></v-text-field>
         </validation-provider>
-        <v-text-field
-          v-model="description"
-          label="投稿者から一言！"
-        ></v-text-field>
 
+        Ï<!-- 講話の紹介 -->
+        <validation-provider
+          v-slot="{ errors }"
+          name="講話の紹介"
+          rules="required"
+        >
+          <v-text-field
+            v-model="description"
+            label="講話の紹介"
+            :error-messages="errors"
+            rows="4"
+          ></v-text-field>
+        </validation-provider>
+
+        <!-- 本文 -->
         <validation-provider v-slot="{ errors }" name="本文" rules="required">
           <v-textarea
             v-model="content"
             :error-messages="errors"
             label="本文"
             auto-grow
-            required
           ></v-textarea>
         </validation-provider>
+
+        <!-- 対象選択 -->
         <validation-provider
           v-slot="{ errors }"
           name="対象学年"
@@ -36,32 +48,33 @@
         >
           <v-select
             v-model="grade_range"
+            :items="grade_range_select"
             item-text="label"
             item-value="value"
-            :items="grade_range_select"
             :error-messages="errors"
             label="対象学年"
             data-vv-name="select"
-            required
           ></v-select>
         </validation-provider>
+
+        <!-- シーン選択 -->
         <validation-provider
           v-slot="{ errors }"
-          name="想定シーン"
+          name="シーンタイプ"
           rules="required"
         >
           <v-select
             v-model="scene_type"
+            :items="scene_type_select"
             item-text="label"
             item-value="value"
-            :items="scene_type_select"
             :error-messages="errors"
             label="シーンタイプ"
             data-vv-name="select"
-            required
           ></v-select>
         </validation-provider>
 
+        <!-- 公開設定 -->
         <validation-provider
           v-slot="{ errors }"
           name="公開設定"
@@ -75,7 +88,6 @@
             :error-messages="errors"
             label="公開設定"
             data-vv-name="select"
-            required
           ></v-select>
         </validation-provider>
 
@@ -88,7 +100,9 @@
         >
           上記内容で更新する
         </v-btn>
-        <v-btn color="blue-grey" class="white--text" @click="clear"> 全て空にする </v-btn>
+        <v-btn color="blue-grey" class="white--text" @click="clear">
+          全て空にする
+        </v-btn>
       </form>
     </validation-observer>
   </v-container>
@@ -97,7 +111,7 @@
 <script>
 import axios from "axios";
 import { mapState } from "vuex";
-import { mapActions } from 'vuex'
+import { mapActions } from "vuex";
 import { required } from "vee-validate/dist/rules";
 import {
   extend,
@@ -131,7 +145,7 @@ export default {
       { label: "中学生", value: "junior_high" },
     ],
     scene_type_select: [
-      { label: "全校集会", value: "all_scholl_assembly" },
+      { label: "全校集会", value: "all_school_assembly" },
       { label: "行事", value: "event" },
     ],
     status_select: [
@@ -148,7 +162,8 @@ export default {
     this.setpostEdit();
   },
   methods: {
-    ...mapActions("message", ["showMessage"]),...mapActions("message", ["showMessage"]),
+    ...mapActions("message", ["showMessage"]),
+    ...mapActions("message", ["showMessage"]),
     submit: function () {
       this.$refs.observer.validate();
     },
@@ -199,9 +214,9 @@ export default {
             this.showMessage({
               message: "編集しました。",
               type: "success",
-              status: true
+              status: true,
             }),
-            this.$router.push({ name: "Postings" });
+              this.$router.push({ name: "Postings" });
           },
           (error) => {
             console.log(error);

--- a/app/javascript/components/Search.vue
+++ b/app/javascript/components/Search.vue
@@ -45,9 +45,14 @@ export default {
             return Qs.stringify(params, { arrayFormat: "brackets" });
           },
         })
-        .then((response) => {
-          console.log(response);
-          this.posts = response.data.posts;
+        .then((res) => {
+          console.log(res);
+          const posts = res.data.posts;
+          for (const post of posts) {
+            post.readActivated = false;
+          }
+          this.posts = posts;
+          // this.posts = response.data.posts;
           this.$router.push({
             name: "SearchResult",
             params: { posts: this.posts, t: new Date().getTime() },

--- a/app/javascript/components/SearchResult.vue
+++ b/app/javascript/components/SearchResult.vue
@@ -1,44 +1,58 @@
 <template>
   <v-container class="grey lighten-5">
-    <h1></h1>
+    <h1>検索結果</h1>
     <v-row>
-      <p v-if="!posts.length">検索条件に合致する講話はありませんでした。</p>
-      <v-col v-for="post in viewPosts" :key="post.id" cols="12" sm="4">
+      <v-col v-for="post in this.viewPosts" :key="post.id" cols="12" sm="4">
         <v-card class="mx-auto" max-width="344">
-          <v-img
-            src="https://cdn.vuetifyjs.com/images/cards/sunshine.jpg"
-            height="200px"
-          ></v-img>
-
-          <v-card-title>
-            {{ post.title }}
-          </v-card-title>
-
-          <v-card-subtitle>
-            {{ post.description }}
-          </v-card-subtitle>
-
-          <v-card-actions>
-            <v-btn color="orange lighten-2" text>
-              <router-link :to="{ path: `/post/${post.id}` }">
-                講話の詳細ページへ
+          <v-card-text>
+            <div>投稿者: {{ post.user.name }}</div>
+            <div>
+              <router-link
+                :to="{ path: `/post/${post.id}` }"
+                style="text-decoration: none"
+              >
+                <p class="text-h5 orange--text">{{ post.title }}</p>
               </router-link>
-            </v-btn>
-
-            <v-spacer></v-spacer>
-          </v-card-actions>
+            </div>
+            <p>{{ post.grade_range_ja }} {{ post.scene_type_ja }}</p>
+            <p>更新日 {{ formatDate(post.updated_at) }}</p>
+            <!-- readmore部分 -->
+            <div>
+              <p>
+                <span v-if="!post.readActivated">
+                  {{ post.description.slice(0, 100) }}
+                </span>
+                <button
+                  class="blue--text"
+                  v-if="!post.readActivated && post.description.length > 100"
+                  @click="post.readActivated = !post.readActivated"
+                >
+                  ...もっと読む
+                </button>
+              </p>
+              <p v-if="post.readActivated">{{ post.description }}</p>
+              <button
+                class="read blue--text"
+                v-if="post.readActivated"
+                @click="post.readActivated = !post.readActivated"
+              >
+                閉じる
+              </button>
+            </div>
+          </v-card-text>
         </v-card>
       </v-col>
-      <v-pagination
-        v-model="page"
-        :length="length"
-        @input="handlePageChange"
-      ></v-pagination>
     </v-row>
+    <v-pagination
+      v-model="page"
+      :length="length"
+      @input="handlePageChange"
+    ></v-pagination>
   </v-container>
 </template>  
 
 <script>
+import dayjs from "dayjs";
 export default {
   name: "SearchResult",
   props: {
@@ -75,6 +89,7 @@ export default {
         this.pageSize * pageNumber
       );
     },
+    formatDate: (dateStr) => dayjs(dateStr).format("YYYY年MM月DD日"),
   },
 };
 </script>

--- a/app/javascript/packs/hello_vue.js
+++ b/app/javascript/packs/hello_vue.js
@@ -7,13 +7,17 @@ import Vuetify from "vuetify";
 import router from "../router/index.js";
 import App from "../app.vue";
 import store from "../store/store.js";
-
-
+import dayjs from "dayjs"; 
+import "dayjs/locale/ja";
 import "vuetify/dist/vuetify.min.css";
 import "@mdi/font/css/materialdesignicons.css";
 
 Vue.use(Vuetify);
 const vuetify = new Vuetify();
+
+// 日付の日本語表示
+dayjs.locale("ja");
+// Vue.prototype.$dayjs = dayjs;
 
 document.addEventListener("DOMContentLoaded", () => {
   const app = new Vue({

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,7 +1,7 @@
 class Post < ApplicationRecord
   belongs_to :user
-  validates :title, :content, :status, :grade_range, :scene_type, presence: true
+  validates :title, :description, :content, :status, :grade_range, :scene_type, presence: true
   enum status: { draft: 0, published: 1 }
   enum grade_range: { elementary: 0, junior_high: 1 }
-  enum scene_type: { all_scholl_assembly: 0, event: 1 }
+  enum scene_type: { all_school_assembly: 0, event: 1 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,8 @@ class User < ActiveRecord::Base
   has_many :posts, dependent: :destroy
 
   enum role: { general: 0, admin: 1 }
-  enum status: { 未設定: 0, 小学校校長: 1, 中学校校長: 2, 元小学校校長: 3, 元中学校校長: 4 }, _prefix: true
+  enum status: { not_set: 0, elementary_school_principal: 1, junior_high_school_principal: 2, former_elementary_school_principal: 3, former_junior_high_school_principal: 4 },
+       _prefix: true
   enum prefecture: { 未設定: 0,
                      北海道: 1, 青森県: 2, 岩手県: 3, 宮城県: 4, 秋田県: 5, 山形県: 6, 福島県: 7,
                      茨城県: 8, 栃木県: 9, 群馬県: 10, 埼玉県: 11, 千葉県: 12, 東京都: 13, 神奈川県: 14,

--- a/app/views/api/postings/index.json.jbuilder
+++ b/app/views/api/postings/index.json.jbuilder
@@ -1,7 +1,15 @@
-json.set! :posts do
-  json.array! @posts do |post|
-    json.extract! post, :id, :title, :description, :content, :status
-  end
-end
+# json.set! :posts do
+#   json.array! @posts do |post|
+#     json.extract! post, :id, :title, :description, :content, :status
+#   end
+# end
 
-# json.array! @posts, :id, :title
+json.posts @posts do |post|
+  json.id post.id
+  json.title post.title
+  json.description post.description
+  json.content post.content
+  json.status post.status
+  json.grade_range_ja post.grade_range_i18n
+  json.scene_type_ja post.scene_type_i18n
+end

--- a/app/views/api/postings/show.json.jbuilder
+++ b/app/views/api/postings/show.json.jbuilder
@@ -1,1 +1,13 @@
-json.extract! @post, :id, :title, :description, :content, :status, :grade_range, :scene_type, :user_id
+# json.extract! @post, :id, :title, :description, :content, :status, :grade_range, :scene_type, :user_id
+
+json.id @post.id
+json.title @post.title
+json.description @post.description
+json.content @post.content
+json.status @post.status
+json.grade_range @post.grade_range
+json.scene_type @post.scene_type
+json.grade_range_ja @post.grade_range_i18n
+json.scene_type_ja @post.scene_type_i18n
+json.user @post.user
+

--- a/app/views/api/posts/index.json.jbuilder
+++ b/app/views/api/posts/index.json.jbuilder
@@ -1,5 +1,16 @@
-json.set! :posts do
-  json.array! @posts do |post|
-    json.extract! post, :id, :title, :description, :content
-  end
+# json.set! :posts do
+#   json.array! @posts do |post|
+#     json.extract! post, :id, :title, :description, :content, :grade_range, :user
+#   end
+# end
+
+json.posts @posts do |post|
+  json.id post.id
+  json.title post.title
+  json.description post.description
+  json.content post.content
+  json.grade_range_ja post.grade_range_i18n
+  json.scene_type_ja post.scene_type_i18n
+  json.updated_at post.updated_at
+  json.user post.user
 end

--- a/app/views/api/posts/search.json.jbuilder
+++ b/app/views/api/posts/search.json.jbuilder
@@ -1,5 +1,15 @@
-json.set! :posts do
-  json.array! @posts do |post|
-    json.extract! post, :id, :title, :description, :content
-  end
+# json.set! :posts do
+#   json.array! @posts do |post|
+#     json.extract! post, :id, :title, :description, :content, :user
+#   end
+# end
+
+json.posts @posts do |post|
+  json.id post.id
+  json.title post.title
+  json.description post.description
+  json.content post.content
+  json.grade_range_ja post.grade_range_i18n
+  json.scene_type_ja post.scene_type_i18n
+  json.user post.user
 end

--- a/app/views/api/posts/show.json.jbuilder
+++ b/app/views/api/posts/show.json.jbuilder
@@ -1,1 +1,10 @@
-json.extract! @post, :id, :title, :description, :content, :status, :grade_range, :scene_type, :user_id
+# json.extract! @post, :id, :title, :description, :content, :status, :grade_range, :scene_type, :user
+
+json.id @post.id
+json.title @post.title
+json.description @post.description
+json.content @post.content
+json.status @post.status
+json.grade_range_ja @post.grade_range_i18n
+json.scene_type_ja @post.scene_type_i18n
+json.user @post.user

--- a/app/views/api/profiles/show.json.jbuilder
+++ b/app/views/api/profiles/show.json.jbuilder
@@ -1,1 +1,8 @@
-json.extract! @user, :id, :name, :self_introduction, :status, :prefecture
+# json.extract! @user, :id, :name, :self_introduction, :status, :prefecture
+
+json.id @user.id
+json.name @user.name
+json.self_introduction @user.self_introduction
+json.status @user.status
+json.status_ja @user.status_i18n
+json.prefecture @user.prefecture

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,7 +23,10 @@ module PrincipalLectureIdeas
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
-
+    config.i18n.default_locale = :ja
+    config.time_zone = 'Asia/Tokyo'
+    config.active_record.default_timezone = :local
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,0 +1,23 @@
+ja:
+  enums:
+    user:
+      role:
+        general: 一般
+        admin: 管理者
+      status:
+        not_set: 未設定
+        elementary_school_principal: 現小学校校長
+        junior_high_school_principal: 現中学校校長
+        former_elementary_school_principal: 元小学校校長
+        former_junior_high_school_principal: 元中学校校長
+
+    post:
+      status:
+        draft: 下書き
+        published: 公開済み
+      grade_range:
+        elementary: 小学生
+        junior_high: 中学生
+      scene_type:
+        all_school_assembly: 全校集会
+        event: 行事

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,13 +1,13 @@
-250.times do |number|
+100.times do |number|
   User.create!(name: Faker::Name.name,
                email: Faker::Internet.email,
                password: "password#{number + 1}",
                password_confirmation: "password#{number + 1}",
                status: rand(0..4),
                prefecture: rand(0..47))
-  Post.create!(title: "校長講話#{number + 1}",
-               description: '宇宙の話をしました。',
-               content: '校長講話本文',
+  Post.create!(title: Faker::Lorem.sentence(word_count: 1),
+               description: Faker::Lorem.paragraph(sentence_count: 7),
+               content: Faker::Lorem.paragraph(sentence_count: 30),
                status: rand(0..1),
                grade_range: rand(0..1),
                scene_type: rand(0..1),

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@types/qs": "^6.9.7",
     "@vue/compiler-sfc": "^3.2.31",
     "axios": "^0.26.1",
+    "dayjs": "^1.11.2",
     "turbolinks": "^5.2.0",
     "vee-validate": "3.2.3",
     "vue": "2.6.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2453,6 +2453,11 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
+dayjs@^1.11.2:
+  version "1.11.2"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.2.tgz#fa0f5223ef0d6724b3d8327134890cfe3d72fbe5"
+  integrity sha512-F4LXf1OeU9hrSYRPTTj/6FbO4HTjPKXvEIC1P2kcnFurViINCVk3ZV0xAS3XVx9MkMsXbbqlK6hjseaYbgKEHw==
+
 de-indent@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"


### PR DESCRIPTION
### 実装内容

- dayjsを導入して講話更新日を日本語表示に
- i18nを導入
- 講話一覧と結果一覧に講話の対象と想定シーンを表示しつつ、全体的な掲載形式を改善
- 講話一覧において文字数が多いdescriptionについてはreadmore機能を追加し折りたたみ表示が可能に