### PR TITLE
他のユーザーの投稿一覧にコメントと参考にされた数が表示されない問題を修正 #91

### DIFF
--- a/app/views/api/v1/profiles/show.json.jbuilder
+++ b/app/views/api/v1/profiles/show.json.jbuilder
@@ -14,4 +14,6 @@ json.posts @posts do |post|
   json.scene_type_ja post.scene_type_i18n
   json.updated_at post.updated_at
   json.user_name post.user.name
+  json.likes_count post.likes.length
+  json.comments_count post.comments.length
 end


### PR DESCRIPTION
### 実装概要

- レスポンスにコメントと参考になったカウントを表示するためのjsonデータを追加