### PR TITLE
管理者画面のuser,post,commentの表示に更新日時が使用されていた箇所を作成日時に変更 #115

### DIFF
--- a/app/views/admins/comments/_comment.html.erb
+++ b/app/views/admins/comments/_comment.html.erb
@@ -9,7 +9,7 @@
     <%= comment.user.name %>
   </td>
   <td>
-    <%= l comment.updated_at, format: :long %>
+    <%= l comment.created_at, format: :long %>
   </td>
   <td>
     <%= link_to t('defaults.show'), admins_comment_path(comment), class: 'btn btn-info' %>

--- a/app/views/admins/comments/index.html.erb
+++ b/app/views/admins/comments/index.html.erb
@@ -2,11 +2,6 @@
   <h1><%= t('.title') %></h1>
   <div class="row">
     <div class="col-md-12 mb-3">
-      <%
-=begin%>
-      <%= render 'search_form' %>
-      <%
-=end%>
     </div>
   </div>
   <div class="row">
@@ -17,7 +12,7 @@
             <th scope="col"><%= Comment.human_attribute_name(:id) %></th>
             <th scope="col"><%= Comment.human_attribute_name(:post) %></th>
             <th scope="col"><%= Comment.human_attribute_name(:user) %></th>
-            <th scope="col"><%= Comment.human_attribute_name(:updated_at) %></th>
+            <th scope="col"><%= Comment.human_attribute_name(:created_at) %></th>
           </tr>
         </thead>
         <tbody>

--- a/app/views/admins/comments/show.html.erb
+++ b/app/views/admins/comments/show.html.erb
@@ -25,8 +25,8 @@
           <td><%= @comment.body %></td>
         </tr>
         <tr>
-          <th scope="row"><%= Comment.human_attribute_name(:updated_at) %></th>
-          <td><%= l @comment.updated_at, format: :long %></td>
+          <th scope="row"><%= Comment.human_attribute_name(:created_at) %></th>
+          <td><%= l @comment.created_at, format: :long %></td>
         </tr>
       </table>
     </div>

--- a/app/views/admins/posts/_post.html.erb
+++ b/app/views/admins/posts/_post.html.erb
@@ -9,7 +9,7 @@
     <%= post.user.name %>
   </td>
   <td>
-    <%= l post.updated_at, format: :long %>
+    <%= l post.created_at, format: :long %>
   </td>
   <td>
     <%= link_to t('defaults.show'), admins_post_path(post), class: 'btn btn-info' %>

--- a/app/views/admins/posts/index.html.erb
+++ b/app/views/admins/posts/index.html.erb
@@ -17,7 +17,7 @@
             <th scope="col"><%= Post.human_attribute_name(:id) %></th>
             <th scope="col"><%= Post.human_attribute_name(:title) %></th>
             <th scope="col"><%= Post.human_attribute_name(:user) %></th>
-            <th scope="col"><%= Post.human_attribute_name(:updated_at) %></th>
+            <th scope="col"><%= Post.human_attribute_name(:created_at) %></th>
           </tr>
         </thead>
         <tbody>

--- a/app/views/admins/users/_user.html.erb
+++ b/app/views/admins/users/_user.html.erb
@@ -11,13 +11,6 @@
   <td>
     <%= l user.updated_at, format: :long %>
   </td>
-  <%
-=begin%>
- <td>
-    <%= l user.created_at, format: :long %>
-  </td> 
-<%
-=end%>
   <td>
     <%= link_to t('defaults.show'), admins_user_path(user), class: 'btn btn-info' %>
     <%= link_to t('defaults.edit'), edit_admins_user_path(user), class: 'btn btn-success' %>

--- a/app/views/admins/users/index.html.erb
+++ b/app/views/admins/users/index.html.erb
@@ -1,20 +1,5 @@
-<%
-=begin%>
-<% content_for(:title, t('.title')) %>
-<%
-=end%>
-
 <div class="container mb-5 pt-2">
   <h1><%= t('.title') %></h1>
-  <%
-=begin%>
-  <div class="row">
-    <div class="col-md-12 mb-3">
-      <%= render 'search_form' %>
-    </div>
-  </div>
-  <%
-=end%>
   <div class="row">
     <div class="col-md-12">
       <table class="table table-striped">
@@ -23,22 +8,7 @@
             <th scope="col"><%= User.human_attribute_name(:id) %></th>
             <th scope="col"><%= User.human_attribute_name(:name) %></th>
             <th scope="col"><%= User.human_attribute_name(:status) %></th>
-            <th scope="col"><%= User.human_attribute_name(:updated_at) %></th>
-
-            <%
-=begin%>
-            以下は元々あったやつ
-            <%
-=end%>
-            <%
-=begin%>
-            <th scope="col"><%= User.human_attribute_name(:id) %></th>
-            <th scope="col"><%= User.human_attribute_name(:full_name) %></th>
-            <th scope="col"><%= User.human_attribute_name(:role) %></th>
             <th scope="col"><%= User.human_attribute_name(:created_at) %></th>
-            <th scope="col"></th>
-            <%
-=end%>
           </tr>
         </thead>
         <tbody>
@@ -49,8 +19,6 @@
   </div>
   <div class="row">
     <div class="col-md-12">
-      <!-- ページネーション -->
-
       <%= paginate @users %>
     </div>
   </div>

--- a/app/views/admins/users/show.html.erb
+++ b/app/views/admins/users/show.html.erb
@@ -30,7 +30,7 @@
         </tr>
 
         <tr>
-          <th scope="row"><%= User.human_attribute_name(:updated_at) %></th>
+          <th scope="row"><%= User.human_attribute_name(:created_at) %></th>
           <td><%= l @user.created_at, format: :long %></td>
         </tr>
       </table>


### PR DESCRIPTION
### 実装概要
- 管理者画面のuser,post,commentの作成日時表示にupdated_atカラムが使用され、表記も「更新日時」となっていた箇所をcreated_atカラムに使用するよう変更し、表記についても「作成日時」に変更