### PR TITLE
管理画面でpost詳細が表示されない問題を修正 #114

### DIFF
--- a/app/controllers/admins/posts_controller.rb
+++ b/app/controllers/admins/posts_controller.rb
@@ -30,6 +30,6 @@ class Admins::PostsController < Admins::BaseController
   end
 
   def set_post
-    @post = Post.find(params[:hashid])
+    @post = Post.find(params[:id])
   end
 end

--- a/app/views/admins/users/_user.html.erb
+++ b/app/views/admins/users/_user.html.erb
@@ -9,7 +9,7 @@
     <%= user.status_i18n %>
   </td>
   <td>
-    <%= l user.updated_at, format: :long %>
+    <%= l user.created_at, format: :long %>
   </td>
   <td>
     <%= link_to t('defaults.show'), admins_user_path(user), class: 'btn btn-info' %>


### PR DESCRIPTION
### 実装概要
- コントローラのshowメソッドでのparamsのキーがhashidとなっていたため管理画面のpost詳細が表示されなかった問題を修正