### PR TITLE
検索エンジンで直接投稿詳細ページを開いた際に、URLに生のidが表示されてしまう問題を修正 #116

### DIFF
--- a/app/controllers/api/v1/postings_controller.rb
+++ b/app/controllers/api/v1/postings_controller.rb
@@ -33,8 +33,8 @@ class Api::V1::PostingsController < Api::V1::ApplicationController
   end
 
   def set_post
-    @post = Post.find(params[:id])
+    # @post = Post.find(params[:id])
+    @post = Post.find_by_hashid(params[:id])
     render status: 401, json: { status: 401, message: 'Unauthorized' } unless @post.user == current_user
-    # @post = current_user.posts.find(params[:id])
   end
 end

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::PostsController < Api::V1::ApplicationController
   end
 
   def show
-    @post = Post.published.find(params[:id])
+    @post = Post.published.find_by_hashid(params[:id])
     render :show, formats: :json, handlers: 'jbuilder'
   end
 

--- a/app/javascript/components/pages/PostingsDetail.vue
+++ b/app/javascript/components/pages/PostingsDetail.vue
@@ -22,7 +22,7 @@
       <v-btn depressed color="success" class="mr-2">
         <router-link
           style="text-decoration: none; color: inherit"
-          :to="{ path: `/postings/edit/${post.id}` }"
+          :to="{ path: `/postings/edit/${this.$route.params.id}` }"
           class="font-weight-bold"
           >編集</router-link
         >

--- a/app/javascript/router/index.js
+++ b/app/javascript/router/index.js
@@ -59,7 +59,7 @@ const router = new Router({
       meta: { requiresAuth: true },
     },
     {
-      path: "/postings/edit/:id(\\d+)",
+      path: "/postings/edit/:id",
       name: "PostingsEdit",
       component: PostingsEdit,
       meta: { requiresAuth: true },

--- a/spec/system/comments_spec.rb
+++ b/spec/system/comments_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'コメントのCRUD機能', type: :system, js: true do
     let!(:post) { create(:post) }
     let!(:user) { create(:user) }
     let!(:comment) { create(:comment, user:, post:) }
-    before { visit("/post/#{post.id}") }
+    before { visit("/post/#{post.hashid}") }
     describe 'コメントの表示' do
       context '講話の詳細ページにアクセス' do
         it 'コメントが表示されるが、編集・削除・新規作成フォームは表示されない' do
@@ -23,7 +23,7 @@ RSpec.describe 'コメントのCRUD機能', type: :system, js: true do
     let!(:comment) { create(:comment, user:, post:) }
     let!(:other_comment) { create(:comment, post:, body: '他人のコメント') }
     before { login(user) }
-    before { visit("/post/#{post.id}") }
+    before { visit("/post/#{post.hashid}") }
     describe 'コメントの表示' do
       context '講話の詳細ページにアクセス' do
         it 'コメント及び編集、削除ボタンと新規投稿フォームが表示されている' do

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe '講話のCRUD機能', type: :system, js: true do
       end
       context '講話の詳細ページにアクセス' do
         it '講話の詳細情報が表示される' do
-          visit("/post/#{post.id}")
+          visit("/post/#{post.hashid}")
           expect(page).to have_content(post.title)
           expect(page).to have_content(post.description)
           expect(page).to have_content(post.content)
@@ -89,10 +89,10 @@ RSpec.describe '講話のCRUD機能', type: :system, js: true do
 
     describe '講話の編集' do
       let!(:post) { create(:post, status: 'draft', user:) }
-      before { visit("/postings/edit/#{post.id}") }
+      before { visit("/postings/edit/#{post.hashid}") }
       context 'フォームの入力値が正常' do
         it '講話の編集が成功する' do
-          visit("/postings/edit/#{post.id}")
+          visit("/postings/edit/#{post.hashid}")
           sleep 2.0
           fill_in 'タイトル', with: 'updated_title'
           page.all('div.v-select__selections')[2].click
@@ -116,7 +116,7 @@ RSpec.describe '講話のCRUD機能', type: :system, js: true do
         let!(:other_user) { create(:user, email: 'other_user@example.com') }
         let!(:other_post) { create(:post, user_id: other_user.id) }
         it '編集ページへのアクセスが失敗する' do
-          visit("/postings/edit/#{other_post.id}")
+          visit("/postings/edit/#{other_post.hashid}")
           expect(page).to_not have_content '講話の編集'
           expect(current_path).to eq root_path
         end
@@ -126,7 +126,7 @@ RSpec.describe '講話のCRUD機能', type: :system, js: true do
       let!(:post) { create(:post, status: 'published', user:) }
       context '削除ボタンを押下しポップアップの指示に従う' do
         it '講話の削除が成功する' do
-          visit("/postings/#{post.id}")
+          visit("/postings/#{post.hashid}")
           click_button '削除'
           sleep 1.0
           click_button 'はい、削除します'


### PR DESCRIPTION
### 実装概要
- 各コントローラのメソッドを生のidではなくhashidでpostをセットするようにロジックを変更
- テストについてもhashidでpostをセットするようにロジックを変更